### PR TITLE
Introduced the pid-pattern flag

### DIFF
--- a/linux.go
+++ b/linux.go
@@ -316,6 +316,11 @@ func main() {
 			logger.Errorf("Failed to read /proc/%s/stat. %s", pid, err)
 		}
 	}
+	if pid == "" {
+		logger.Errorf("Not found pid")
+		os.Exit(1)
+	}
+
 	metricKey = *optMetricKey
 
 	var procStats LinuxProcStatsPlugin


### PR DESCRIPTION
It allows to take a regexp pattern string instead of a pid or a pidfile argument.

```
# for example
$ /path/to/mackerel-plugin-linux-proc-stats -metric-key-prefix redis-server -pid-pattern redis-server
redis-server_process.num.running        0.000000        1459420708
redis-server_process.num.processes      1.000000        1459420708
redis-server_process.num.threads        3.000000        1459420708
redis-server_process.cpu.usage  4.126039        1459420708
redis-server_process.memory.vsize       96747520.000000 1459420708
redis-server_process.memory.rss 42307584.000000 1459420708
```

I want to use this plugin for processes generated no pidfile.
This implementation skip a pid for the plugin command process itself and its parent process.
- [mackerel-agent run a plugin command via /bin/sh -c](https://github.com/mackerelio/mackerel-agent/blob/092508166b2e6c17d14c82bced877468d4639c91/util/util.go#L25), so its parent process should be skipped.

It can be supported(avoided) with flags like `-match-itself` and `-match-parent`, but I didn't increase new two flags because I have no idea about these specific  demands.

Please review PR, and merge If there is no problem.

And ... I want you to send a pull request to https://github.com/mackerelio/mackerel-agent-plugins to make deploy easier ^^
