### PR TITLE
Option: exclude cumulative cpu time (cutime and cstime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Linux processes metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-linux-proc-stats -pid=<pid>|-pidfile=<pidfile>|-process-pattern=<process pattern> [-metric-key-prefix=<metric-key-prefix>] [-tempfile=<tempfile>] [-follow-child-processes]
+mackerel-plugin-linux-proc-stats -pid=<pid>|-pidfile=<pidfile>|-process-pattern=<process pattern> [-metric-key-prefix=<metric-key-prefix>] [-tempfile=<tempfile>] [-follow-child-processes] [-include-dead-children=0]
 ```
 
 ```shell
@@ -12,6 +12,8 @@ $ ./mackerel-plugin-linux-proc-stats --help
 Usage of ./mackerel-plugin-linux-proc-stats:
   -follow-child-processes
         Follow child processes
+  -include-dead-children
+        Include dead kids in cpu sum (default true)
   -metric-key-prefix string
         Metric key prefix
   -pid string


### PR DESCRIPTION
`cutime and cstime` are resource counters for reaped dead child processes.
- https://github.com/torvalds/linux/blob/db06d759d6cf903aeda8c107fd3abd366dd80200/include/linux/sched.h#L751-L752
- https://github.com/torvalds/linux/blob/db06d759d6cf903aeda8c107fd3abd366dd80200/kernel/exit.c#L1054-L1055

I expect this plugin works for cpu usage similar as `ps` command with no special option.
- The td-agent supervisor(parent) process normally consume no(=very few) cpu time.

```
$ ps auxf | grep [t]d-agent
td-agent 18778  0.0  0.1 249308 32088 ?        Sl   Jun06   0:00  \_ /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent -v -c /etc/td-agent/td-agent.rb
td-agent 28362 40.5  4.8 4822432 1530072 ?     Sl   Jun13 3388:07      \_ /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent -v -c /etc/td-agent/td-agent.rb
```

But, this plugin works same as `ps S` command.
- https://github.com/mmalecki/procps/blob/fe4c4a7314f32907b9f558ad0d8b8d0ff1cc76be/ps/parser.c#L569-L572
- https://github.com/mmalecki/procps/blob/fe4c4a7314f32907b9f558ad0d8b8d0ff1cc76be/ps/output.c#L457

```
$ ps S auxf | grep [t]d-agent
td-agent 18778 22.0  0.1 249308 32088 ?        Sl   Jun06 4073:24  \_ /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent -v -c /etc/td-agent/td-agent.rb
td-agent 28362 40.5  4.8 4822432 1528632 ?     Sl   Jun13 3389:55      \_ /opt/td-agent/embedded/bin/ruby /usr/sbin/td-agent -v -c /etc/td-agent/td-agent.rb
```

This PR implements a new option `include-dead-children` to be able to exclude those cumulative cpu time from metric results, while keeping compatibility.

```
# include dead children
$ ./mackerel-plugin-linux-proc-stats-dd0ee2a \
-process-pattern td-agent \
| grep cpu.usage
_process.cpu.usage      62.526238       1466310917

# exclude dead children
$ ./mackerel-plugin-linux-proc-stats-dd0ee2a \
-process-pattern td-agent \
--include-dead-children=0 \
| grep cpu.usage
_process.cpu.usage      40.549812       1466310931
```
